### PR TITLE
Fix URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Project Info
 ------------
 
 - Homepage: `https://pypi.python.org/pypi/PyDrive <https://pypi.python.org/pypi/PyDrive>`_
-- Documentation: `Official documentation on GitHub pages <https://googledrive.github.io/PyDrive/docs/build/html/index.html>`_
+- Documentation: `Official documentation on GitHub pages <https://gsuitedevs.github.io/PyDrive/docs/build/html/index.html>`_
 - GitHub: `https://github.com/googledrive/PyDrive <https://github.com/googledrive/PyDrive>`_
 
 Features of PyDrive
@@ -34,7 +34,7 @@ To install the current development version from GitHub, use:
 
 ::
 
-    $  pip install git+https://github.com/googledrive/PyDrive.git#egg=PyDrive
+    $  pip install git+https://github.com/gsuitedevs/PyDrive.git#egg=PyDrive
 
 OAuth made easy
 ---------------


### PR DESCRIPTION
A URL was kept in the old-fashion (`googledrive`, not `gsuitedevs`). This pull requests aims to repair that.