### PR TITLE
Allows sorted() for GoogleDriveFile objects

### DIFF
--- a/pydrive/files.py
+++ b/pydrive/files.py
@@ -148,7 +148,7 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
         raise FileNotUploadedError()
 
   def __lt__(self, other):
-    """ Allows sorted() function for GoogleDriveFile objects """
+    """Allows sorted() function for GoogleDriveFile objects."""
     return self['title'] < other['title']
 
   def SetContentString(self, content, encoding='utf-8'):

--- a/pydrive/files.py
+++ b/pydrive/files.py
@@ -147,6 +147,10 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
       else:
         raise FileNotUploadedError()
 
+  def __lt__(self, other):
+    """ Allows sorted() function for GoogleDriveFile objects """
+    return self['title'] < other['title']
+
   def SetContentString(self, content, encoding='utf-8'):
     """Set content of this file to be a string.
 

--- a/pydrive/test/test_filelist.py
+++ b/pydrive/test/test_filelist.py
@@ -21,7 +21,7 @@ class GoogleDriveFileListTest(unittest.TestCase):
     flist = drive.ListFile({'q': "title = '%s' and trashed = false"
                                  % self.title})
     files = flist.GetList()  # Auto iterate every file
-    for file1 in self.file_list:
+    for file1 in sorted(self.file_list):
       found = False
       for file2 in files:
         if file1['id'] == file2['id']:


### PR DESCRIPTION
Add `__le()__` function to allow `sorted()` capability for GoogleDriveFile objects.

Example:
```python
file_list = drive.ListFile({'q': "'%s' in parents and trashed=false"%id}).GetList()
for file in sorted(file_list):
    ...
```