### PR TITLE
cache_discovery to be False

### DIFF
--- a/pydrive/auth.py
+++ b/pydrive/auth.py
@@ -520,7 +520,7 @@ class GoogleAuth(ApiAttributeMixin, object):
     if self.access_token_expired:
       raise AuthenticationError('No valid credentials provided to authorize')
     self.http = self.credentials.authorize(self.http)
-    self.service = build('drive', 'v2', http=self.http)
+    self.service = build('drive', 'v2', http=self.http, cache_discovery=False)
 
   def Get_Http_Object(self):
     """Create and authorize an httplib2.Http object. Necessary for


### PR DESCRIPTION
This change fix the error below:

```
    'file_cache is unavailable when using oauth2client >= 4.0.0 or google-auth')
ImportError: file_cache is unavailable when using oauth2client >= 4.0.0 or google-auth
```