### PR TITLE
Update GoogleDriveFile to use V3 shared drive query parameters

### DIFF
--- a/pydrive/files.py
+++ b/pydrive/files.py
@@ -60,10 +60,9 @@ class GoogleDriveFileList(ApiResourceList):
 
     :returns: list -- list of pydrive.files.GoogleDriveFile.
     """
-    # Teamdrive support
-    self['corpus'] = 'DEFAULT'
-    self['supportsTeamDrives'] = True
-    self['includeTeamDriveItems'] = True
+    # SharedDrive support (aka TeamDrive)
+    self['includeItemsFromAllDrives'] = True
+    self['supportsAllDrives'] = True
 
     self.metadata = self.auth.service.files().list(**dict(self)).execute(
       http=self.http)


### PR DESCRIPTION
Current team drive support does not work. This PR updates query parameters to V3 shared drive parameters.

Should fix https://github.com/gsuitedevs/PyDrive/issues/149