### PR TITLE
Handle GetList HttpError exceptions properly

### DIFF
--- a/pydrive/files.py
+++ b/pydrive/files.py
@@ -64,9 +64,11 @@ class GoogleDriveFileList(ApiResourceList):
     self['corpus'] = 'DEFAULT'
     self['supportsTeamDrives'] = True
     self['includeTeamDriveItems'] = True
-
-    self.metadata = self.auth.service.files().list(**dict(self)).execute(
-      http=self.http)
+    try:
+      self.metadata = self.auth.service.files().list(**dict(self)).execute(
+        http=self.http)
+    except errors.HttpError as error:
+      raise ApiRequestError(error)
 
     result = []
     for file_metadata in self.metadata['items']:


### PR DESCRIPTION
_GetList should handle HttpError similarly to others 9 places running `.execute`